### PR TITLE
Properly passing ref_genome

### DIFF
--- a/R/extract_goi_superfreq.R
+++ b/R/extract_goi_superfreq.R
@@ -139,9 +139,9 @@ extract_goi_supefreq <- function(superFreq_R_path = superFreq_R_path,
     labels = superFreq:::storyToLabel(MoI, stories$variants, genome=ref_genome, mergeCNAs=F)[as.character(seq(along.with=MoI$x1)),]
     MoI$label = labels$label
     MoI$severity = labels$severity
-    MoI$chr = superFreq:::xToChr(MoI$x1)
-    MoI$start = superFreq:::xToPos(MoI$x1)
-    MoI$end = superFreq:::xToPos(MoI$x2)
+    MoI$chr = superFreq:::xToChr(MoI$x1, genome=ref_genome)
+    MoI$start = superFreq:::xToPos(MoI$x1, genome=ref_genome)
+    MoI$end = superFreq:::xToPos(MoI$x2, genome=ref_genome)
 
     # Convert to long format SNVs
     MoI_stories <- data.frame(MoI$stories)

--- a/R/import_goi_superfreq.R
+++ b/R/import_goi_superfreq.R
@@ -139,9 +139,9 @@ extract_goi_supefreq <- function(superFreq_R_path = superFreq_R_path,
     labels = superFreq:::storyToLabel(MoI, stories$variants, genome=ref_genome, mergeCNAs=F)[as.character(seq(along.with=MoI$x1)),]
     MoI$label = labels$label
     MoI$severity = labels$severity
-    MoI$chr = superFreq:::xToChr(MoI$x1)
-    MoI$start = superFreq:::xToPos(MoI$x1)
-    MoI$end = superFreq:::xToPos(MoI$x2)
+    MoI$chr = superFreq:::xToChr(MoI$x1, genome=ref_genome)
+    MoI$start = superFreq:::xToPos(MoI$x1, genome=ref_genome)
+    MoI$end = superFreq:::xToPos(MoI$x2, genome=ref_genome)
 
     # Convert to long format SNVs
     MoI_stories <- data.frame(MoI$stories)


### PR DESCRIPTION
Should fix #11 

The default in superFreq:::xToChr and xToPos is genome='hg19', and as we use hg38 but don't pass it on, we get the wrong positions and sometimes chromosome.